### PR TITLE
enhancement: bubble cause error status

### DIFF
--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -45,10 +45,14 @@ export class SupaStripeStackError extends Error {
     super();
     this.name = "SupaStripeStackError 👀";
     this.message = message;
-    this.status = status;
+    this.status = isSupaStripeStackError(cause) ? cause.status : status;
     this.cause = cause;
     this.metadata = metadata;
     this.tag = tag;
     this.traceId = traceId || createId();
   }
+}
+
+function isSupaStripeStackError(cause: unknown): cause is SupaStripeStackError {
+  return cause instanceof SupaStripeStackError;
 }


### PR DESCRIPTION
SupaStripeStackError will now set its `status` equal to `cause.status` if `cause` is `instanceof SupaStripeStackError`.
This allows you to keep a status code that you may have set deeper in your service.